### PR TITLE
feat(forms): add preliminary library backend support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:webpack": "./scripts/increase-limits.sh nest build --webpack --webpackPath webpack.config.js --watch",
     "dev:tsx": "tsx watch src/main.ts",
     "start:debug": "npx prisma generate && ./scripts/increase-limits.sh nest start --debug --watch --preserveWatchOutput",
-    "seed": "node dist/prisma/seed.js",
+    "seed": "npx ts-node prisma/seed.ts",
     "prisma:run": "npx ts-node prisma/run.ts",
     "migrate": "npx prisma migrate dev && npx prisma generate",
     "reset": "npx prisma migrate reset && yarn seed",
@@ -164,6 +164,9 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.5.3",
     "webpack-node-externals": "^3.0.0"
+  },
+  "prisma": {
+    "seed": "npx ts-node prisma/seed.ts"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/prisma/migrations/20260330190000_add_form_preliminary_library/migration.sql
+++ b/prisma/migrations/20260330190000_add_form_preliminary_library/migration.sql
@@ -1,0 +1,100 @@
+-- CreateEnum
+CREATE TYPE "FormPreliminaryLibraryQuestionTypeEnum" AS ENUM ('SINGLE_CHOICE', 'TEXT');
+
+-- CreateEnum
+CREATE TYPE "FormPreliminaryLibraryCategoryEnum" AS ENUM ('DEMOGRAPHIC', 'ORGANIZATIONAL', 'SEGMENTATION', 'OTHER');
+
+-- CreateTable
+CREATE TABLE "form_preliminary_library_question" (
+    "id" TEXT NOT NULL,
+    "system" BOOLEAN NOT NULL DEFAULT false,
+    "company_id" TEXT,
+    "name" TEXT NOT NULL,
+    "question_text" TEXT NOT NULL,
+    "question_type" "FormPreliminaryLibraryQuestionTypeEnum" NOT NULL,
+    "category" "FormPreliminaryLibraryCategoryEnum" NOT NULL,
+    "identifier_type" "FormIdentifierTypeEnum" NOT NULL,
+    "accept_other" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "form_preliminary_library_question_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "form_preliminary_library_question_option" (
+    "id" TEXT NOT NULL,
+    "library_question_id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "value" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "form_preliminary_library_question_option_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "form_preliminary_library_block" (
+    "id" TEXT NOT NULL,
+    "system" BOOLEAN NOT NULL DEFAULT false,
+    "company_id" TEXT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "form_preliminary_library_block_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "form_preliminary_library_block_item" (
+    "id" TEXT NOT NULL,
+    "block_id" TEXT NOT NULL,
+    "library_question_id" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "form_preliminary_library_block_item_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_question_company_id_idx" ON "form_preliminary_library_question"("company_id");
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_question_system_idx" ON "form_preliminary_library_question"("system");
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_question_category_idx" ON "form_preliminary_library_question"("category");
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_question_option_library_question_id_idx" ON "form_preliminary_library_question_option"("library_question_id");
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_block_company_id_idx" ON "form_preliminary_library_block"("company_id");
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_block_system_idx" ON "form_preliminary_library_block"("system");
+
+-- CreateIndex
+CREATE INDEX "form_preliminary_library_block_item_block_id_idx" ON "form_preliminary_library_block_item"("block_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "form_preliminary_library_block_item_block_id_library_question_id_key" ON "form_preliminary_library_block_item"("block_id", "library_question_id");
+
+-- AddForeignKey
+ALTER TABLE "form_preliminary_library_question" ADD CONSTRAINT "form_preliminary_library_question_company_id_fkey" FOREIGN KEY ("company_id") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "form_preliminary_library_question_option" ADD CONSTRAINT "form_preliminary_library_question_option_library_question_id_fkey" FOREIGN KEY ("library_question_id") REFERENCES "form_preliminary_library_question"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "form_preliminary_library_block" ADD CONSTRAINT "form_preliminary_library_block_company_id_fkey" FOREIGN KEY ("company_id") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "form_preliminary_library_block_item" ADD CONSTRAINT "form_preliminary_library_block_item_block_id_fkey" FOREIGN KEY ("block_id") REFERENCES "form_preliminary_library_block"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "form_preliminary_library_block_item" ADD CONSTRAINT "form_preliminary_library_block_item_library_question_id_fkey" FOREIGN KEY ("library_question_id") REFERENCES "form_preliminary_library_question"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260403135905_/migration.sql
+++ b/prisma/migrations/20260403135905_/migration.sql
@@ -1,0 +1,8 @@
+-- RenameForeignKey
+ALTER TABLE "form_preliminary_library_question_option" RENAME CONSTRAINT "form_preliminary_library_question_option_library_question_id_fk" TO "form_preliminary_library_question_option_library_question__fkey";
+
+-- RenameIndex
+ALTER INDEX "form_preliminary_library_block_item_block_id_library_question_i" RENAME TO "form_preliminary_library_block_item_block_id_library_questi_key";
+
+-- RenameIndex
+ALTER INDEX "form_preliminary_library_question_option_library_question_id_id" RENAME TO "form_preliminary_library_question_option_library_question_i_idx";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -366,6 +366,8 @@ model Company {
   CompanyFlags               CompanyFlags?
   formAiAnalyses             FormAiAnalysis[]
   aiPendingActions           AiPendingAction[]
+  formPreliminaryLibraryQuestions FormPreliminaryLibraryQuestion[]
+  formPreliminaryLibraryBlocks    FormPreliminaryLibraryBlock[]
 
   @@index([name])
   @@index([isClinic])
@@ -1561,6 +1563,79 @@ model FormQuestionIdentifier {
   deleted_at         DateTime?
 
   form_question_data FormQuestionDetailsData[]
+}
+
+/// Biblioteca de Perguntas Preliminares — templates reutilizáveis (cópia na aplicação; sem FK viva).
+model FormPreliminaryLibraryQuestion {
+  id              String                               @id @default(cuid())
+  system          Boolean                              @default(false)
+  company_id      String?
+  name            String
+  question_text   String
+  question_type   FormPreliminaryLibraryQuestionTypeEnum
+  category        FormPreliminaryLibraryCategoryEnum
+  identifier_type FormIdentifierTypeEnum
+  accept_other    Boolean                              @default(false)
+  created_at      DateTime                             @default(now())
+  updated_at      DateTime                             @updatedAt
+  deleted_at      DateTime?
+
+  company    Company?                           @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  options    FormPreliminaryLibraryQuestionOption[]
+  blockItems FormPreliminaryLibraryBlockItem[]
+
+  @@index([company_id])
+  @@index([system])
+  @@index([category])
+  @@map("form_preliminary_library_question")
+}
+
+model FormPreliminaryLibraryQuestionOption {
+  id                   String   @id @default(cuid())
+  library_question_id  String
+  text                 String
+  order                Int
+  value                Int?
+  created_at           DateTime @default(now())
+  updated_at           DateTime @updatedAt
+  deleted_at           DateTime?
+
+  library_question FormPreliminaryLibraryQuestion @relation(fields: [library_question_id], references: [id], onDelete: Cascade)
+
+  @@index([library_question_id])
+  @@map("form_preliminary_library_question_option")
+}
+
+model FormPreliminaryLibraryBlock {
+  id          String    @id @default(cuid())
+  system      Boolean   @default(false)
+  company_id  String?
+  name        String
+  description String?
+  created_at  DateTime  @default(now())
+  updated_at  DateTime  @updatedAt
+  deleted_at  DateTime?
+
+  company Company?                        @relation(fields: [company_id], references: [id], onDelete: Cascade)
+  items   FormPreliminaryLibraryBlockItem[]
+
+  @@index([company_id])
+  @@index([system])
+  @@map("form_preliminary_library_block")
+}
+
+model FormPreliminaryLibraryBlockItem {
+  id                  String @id @default(cuid())
+  block_id            String
+  library_question_id String
+  order               Int
+
+  block            FormPreliminaryLibraryBlock    @relation(fields: [block_id], references: [id], onDelete: Cascade)
+  library_question FormPreliminaryLibraryQuestion @relation(fields: [library_question_id], references: [id], onDelete: Restrict)
+
+  @@unique([block_id, library_question_id])
+  @@index([block_id])
+  @@map("form_preliminary_library_block_item")
 }
 
 model GenerateSource {
@@ -2974,6 +3049,18 @@ enum FormIdentifierTypeEnum {
   OFFICE
   SUB_OFFICE
   CUSTOM
+}
+
+enum FormPreliminaryLibraryQuestionTypeEnum {
+  SINGLE_CHOICE
+  TEXT
+}
+
+enum FormPreliminaryLibraryCategoryEnum {
+  DEMOGRAPHIC
+  ORGANIZATIONAL
+  SEGMENTATION
+  OTHER
 }
 
 enum FormTypeEnum {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from "@prisma/client";
 import { seedCompany } from "./seed/company";
 import { seedEmployees } from "./seed/employees";
 import { seedEpis } from "./seed/epis";
+import { seedFormPreliminaryLibrary } from "./seed/form-preliminary-library";
 import { seedRisks } from "./seed/risks";
 import { seedUsers } from "./seed/user";
 
@@ -14,6 +15,7 @@ const createUserAndCompany = async () => {
   await seedRisks(prisma, companyId);
   await seedUsers(prisma, companyId);
   await seedEpis(prisma);
+  await seedFormPreliminaryLibrary(prisma);
 };
 
 async function main() {

--- a/prisma/seed/form-preliminary-library.ts
+++ b/prisma/seed/form-preliminary-library.ts
@@ -1,0 +1,145 @@
+import {
+  FormIdentifierTypeEnum,
+  FormPreliminaryLibraryCategoryEnum,
+  FormPreliminaryLibraryQuestionTypeEnum,
+  PrismaClient,
+} from '@prisma/client';
+
+type Opt = { text: string; order: number; value?: number | null };
+
+/**
+ * Templates globais (system=true, company_id=null) — seed idempotente por nome do bloco.
+ */
+export async function seedFormPreliminaryLibrary(prisma: PrismaClient) {
+  const existingBlock = await prisma.formPreliminaryLibraryBlock.findFirst({
+    where: { system: true, name: 'Bloco Demográfico Padrão', deleted_at: null },
+  });
+  if (existingBlock) {
+    console.log('[seed] Form preliminary library already seeded, skipping.');
+    return;
+  }
+
+  const questionsData: {
+    name: string;
+    question_text: string;
+    options: Opt[];
+  }[] = [
+    {
+      name: 'Gênero',
+      question_text: 'Gênero',
+      options: [
+        { text: 'Masculino', order: 0, value: 0 },
+        { text: 'Feminino', order: 1, value: 1 },
+        { text: 'Não binário', order: 2, value: 2 },
+        { text: 'Prefiro não responder', order: 3, value: 3 },
+      ],
+    },
+    {
+      name: 'Faixa etária',
+      question_text: 'Faixa etária',
+      options: [
+        { text: 'Até 30 anos', order: 0, value: 0 },
+        { text: 'De 31 a 40 anos', order: 1, value: 1 },
+        { text: 'De 41 a 50 anos', order: 2, value: 2 },
+        { text: 'De 51 a 60 anos', order: 3, value: 3 },
+        { text: 'Acima de 60 anos', order: 4, value: 4 },
+      ],
+    },
+    {
+      name: 'Como você se declara',
+      question_text: 'Como você se declara',
+      options: [
+        { text: 'Branco(a)', order: 0, value: 0 },
+        { text: 'Negro(a) (pretos e pardos)', order: 1, value: 1 },
+        { text: 'Indígena', order: 2, value: 2 },
+        { text: 'Amarelo(a) (origem oriental)', order: 3, value: 3 },
+        { text: 'Prefiro não responder', order: 4, value: 4 },
+      ],
+    },
+    {
+      name: 'Escolaridade',
+      question_text: 'Escolaridade',
+      options: [
+        { text: 'Ensino Médio', order: 0, value: 0 },
+        { text: 'Superior Completo', order: 1, value: 1 },
+        { text: 'Especialização', order: 2, value: 2 },
+        { text: 'Mestrado', order: 3, value: 3 },
+        { text: 'Doutorado', order: 4, value: 4 },
+      ],
+    },
+    {
+      name: 'Tempo de empresa',
+      question_text: 'Tempo de empresa',
+      options: [
+        { text: 'Menos de 1 ano', order: 0, value: 0 },
+        { text: 'De 1 a 3 anos', order: 1, value: 1 },
+        { text: 'De 4 a 6 anos', order: 2, value: 2 },
+        { text: 'De 7 a 10 anos', order: 3, value: 3 },
+        { text: 'Acima de 10 anos', order: 4, value: 4 },
+      ],
+    },
+    {
+      name: 'Área de atuação na empresa (macro área)',
+      question_text: 'Área de atuação na empresa (macro área)',
+      options: [
+        { text: 'Administrativa', order: 0, value: 0 },
+        { text: 'Operacional', order: 1, value: 1 },
+        { text: 'Apoio / Serviços gerais', order: 2, value: 2 },
+        { text: 'Gestão / Coordenação', order: 3, value: 3 },
+      ],
+    },
+    {
+      name: 'Regime de trabalho',
+      question_text: 'Regime de trabalho',
+      options: [
+        { text: 'Presencial', order: 0, value: 0 },
+        { text: 'Híbrido', order: 1, value: 1 },
+        { text: 'Teletrabalho (Home Office)', order: 2, value: 2 },
+      ],
+    },
+  ];
+
+  const questionIds: string[] = [];
+
+  await prisma.$transaction(async (tx) => {
+    for (const q of questionsData) {
+      const created = await tx.formPreliminaryLibraryQuestion.create({
+        data: {
+          system: true,
+          company_id: null,
+          name: q.name,
+          question_text: q.question_text,
+          question_type: FormPreliminaryLibraryQuestionTypeEnum.SINGLE_CHOICE,
+          category: FormPreliminaryLibraryCategoryEnum.DEMOGRAPHIC,
+          identifier_type: FormIdentifierTypeEnum.CUSTOM,
+          accept_other: false,
+          options: {
+            create: q.options.map((o) => ({
+              text: o.text,
+              order: o.order,
+              value: o.value ?? null,
+            })),
+          },
+        },
+      });
+      questionIds.push(created.id);
+    }
+
+    const block = await tx.formPreliminaryLibraryBlock.create({
+      data: {
+        system: true,
+        company_id: null,
+        name: 'Bloco Demográfico Padrão',
+        description: 'Conjunto padrão de perguntas demográficas para segmentação analítica.',
+        items: {
+          create: questionIds.map((library_question_id, order) => ({
+            library_question_id,
+            order,
+          })),
+        },
+      },
+    });
+
+    console.log(`[seed] Form preliminary library: ${questionIds.length} questions + block ${block.id}`);
+  });
+}

--- a/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-blocks/controllers/browse-form-preliminary-library-blocks.query.ts
+++ b/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-blocks/controllers/browse-form-preliminary-library-blocks.query.ts
@@ -1,0 +1,20 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class BrowseFormPreliminaryLibraryBlocksQuery {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}

--- a/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-blocks/use-cases/browse-form-preliminary-library-blocks.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-blocks/use-cases/browse-form-preliminary-library-blocks.usecase.ts
@@ -1,0 +1,32 @@
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { getPagination } from '@/@v2/shared/utils/database/get-pagination';
+import { Injectable } from '@nestjs/common';
+
+export namespace BrowseFormPreliminaryLibraryBlocksUseCase {
+  export type Params = {
+    companyId: string;
+    search?: string;
+    page?: number;
+    limit?: number;
+  };
+}
+
+@Injectable()
+export class BrowseFormPreliminaryLibraryBlocksUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: BrowseFormPreliminaryLibraryBlocksUseCase.Params) {
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 20;
+    const { offSet, limit: take } = getPagination(page, limit);
+
+    const { data, count } = await this.dao.browseBlocks({
+      companyId: params.companyId,
+      search: params.search,
+      skip: offSet,
+      take,
+    });
+
+    return { data, count, page, limit: take };
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-questions/controllers/browse-form-preliminary-library-questions.query.ts
+++ b/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-questions/controllers/browse-form-preliminary-library-questions.query.ts
@@ -1,0 +1,25 @@
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { FormPreliminaryLibraryCategoryEnum } from '@prisma/client';
+
+export class BrowseFormPreliminaryLibraryQuestionsQuery {
+  @IsOptional()
+  @IsEnum(FormPreliminaryLibraryCategoryEnum)
+  category?: FormPreliminaryLibraryCategoryEnum;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+}

--- a/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-questions/use-cases/browse-form-preliminary-library-questions.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/browse-form-preliminary-library-questions/use-cases/browse-form-preliminary-library-questions.usecase.ts
@@ -1,0 +1,40 @@
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { getPagination } from '@/@v2/shared/utils/database/get-pagination';
+import { Injectable } from '@nestjs/common';
+import { FormPreliminaryLibraryCategoryEnum } from '@prisma/client';
+
+export namespace BrowseFormPreliminaryLibraryQuestionsUseCase {
+  export type Params = {
+    companyId: string;
+    category?: FormPreliminaryLibraryCategoryEnum;
+    search?: string;
+    page?: number;
+    limit?: number;
+  };
+}
+
+@Injectable()
+export class BrowseFormPreliminaryLibraryQuestionsUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: BrowseFormPreliminaryLibraryQuestionsUseCase.Params) {
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 20;
+    const { offSet, limit: take } = getPagination(page, limit);
+
+    const { data, count } = await this.dao.browseQuestions({
+      companyId: params.companyId,
+      category: params.category,
+      search: params.search,
+      skip: offSet,
+      take,
+    });
+
+    return {
+      data,
+      count,
+      page,
+      limit: take,
+    };
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-block/controllers/create-form-preliminary-library-block.body.ts
+++ b/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-block/controllers/create-form-preliminary-library-block.body.ts
@@ -1,0 +1,25 @@
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+export class CreateFormPreliminaryLibraryBlockItemBody {
+  @IsString()
+  libraryQuestionId!: string;
+
+  @IsInt()
+  order!: number;
+}
+
+export class CreateFormPreliminaryLibraryBlockBody {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateFormPreliminaryLibraryBlockItemBody)
+  @ArrayMinSize(1)
+  items!: CreateFormPreliminaryLibraryBlockItemBody[];
+}

--- a/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-block/use-cases/create-form-preliminary-library-block.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-block/use-cases/create-form-preliminary-library-block.usecase.ts
@@ -1,0 +1,40 @@
+import { assertValidSystemCompanyPair } from '@/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation';
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+export namespace CreateFormPreliminaryLibraryBlockUseCase {
+  export type Params = {
+    companyId: string;
+    name: string;
+    description?: string | null;
+    items: { libraryQuestionId: string; order: number }[];
+  };
+}
+
+@Injectable()
+export class CreateFormPreliminaryLibraryBlockUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: CreateFormPreliminaryLibraryBlockUseCase.Params) {
+    const system = false;
+    assertValidSystemCompanyPair(system, params.companyId);
+
+    if (!params.items?.length) {
+      throw new BadRequestException('O bloco deve conter pelo menos uma pergunta.');
+    }
+
+    const questionIds = params.items.map((i) => i.libraryQuestionId);
+    await this.dao.assertQuestionsAccessibleForBlock(params.companyId, questionIds);
+
+    return this.dao.createBlockWithItems({
+      system,
+      company_id: params.companyId,
+      name: params.name,
+      description: params.description,
+      items: params.items.map((i) => ({
+        library_question_id: i.libraryQuestionId,
+        order: i.order,
+      })),
+    });
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-question/controllers/create-form-preliminary-library-question.body.ts
+++ b/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-question/controllers/create-form-preliminary-library-question.body.ts
@@ -1,0 +1,54 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import {
+  FormIdentifierTypeEnum,
+  FormPreliminaryLibraryCategoryEnum,
+  FormPreliminaryLibraryQuestionTypeEnum,
+} from '@prisma/client';
+
+export class CreateFormPreliminaryLibraryQuestionOptionBody {
+  @IsString()
+  text!: string;
+
+  @IsInt()
+  order!: number;
+
+  @IsOptional()
+  @IsInt()
+  value?: number | null;
+}
+
+export class CreateFormPreliminaryLibraryQuestionBody {
+  @IsString()
+  name!: string;
+
+  @IsString()
+  questionText!: string;
+
+  @IsEnum(FormPreliminaryLibraryQuestionTypeEnum)
+  questionType!: FormPreliminaryLibraryQuestionTypeEnum;
+
+  @IsEnum(FormPreliminaryLibraryCategoryEnum)
+  category!: FormPreliminaryLibraryCategoryEnum;
+
+  @IsEnum(FormIdentifierTypeEnum)
+  identifierType!: FormIdentifierTypeEnum;
+
+  @IsBoolean()
+  acceptOther!: boolean;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateFormPreliminaryLibraryQuestionOptionBody)
+  @ArrayMinSize(0)
+  options!: CreateFormPreliminaryLibraryQuestionOptionBody[];
+}

--- a/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-question/use-cases/create-form-preliminary-library-question.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/create-form-preliminary-library-question/use-cases/create-form-preliminary-library-question.usecase.ts
@@ -1,0 +1,49 @@
+import {
+  assertValidSystemCompanyPair,
+  rejectSectorIdentifierForLibrary,
+  validateOptionsForQuestionType,
+} from '@/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation';
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { Injectable } from '@nestjs/common';
+import {
+  FormIdentifierTypeEnum,
+  FormPreliminaryLibraryCategoryEnum,
+  FormPreliminaryLibraryQuestionTypeEnum,
+} from '@prisma/client';
+
+export namespace CreateFormPreliminaryLibraryQuestionUseCase {
+  export type Params = {
+    companyId: string;
+    name: string;
+    questionText: string;
+    questionType: FormPreliminaryLibraryQuestionTypeEnum;
+    category: FormPreliminaryLibraryCategoryEnum;
+    identifierType: FormIdentifierTypeEnum;
+    acceptOther: boolean;
+    options: { text: string; order: number; value?: number | null }[];
+  };
+}
+
+@Injectable()
+export class CreateFormPreliminaryLibraryQuestionUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: CreateFormPreliminaryLibraryQuestionUseCase.Params) {
+    const system = false;
+    assertValidSystemCompanyPair(system, params.companyId);
+    rejectSectorIdentifierForLibrary(params.identifierType);
+    validateOptionsForQuestionType(params.questionType, params.identifierType, params.options);
+
+    return this.dao.createQuestionWithOptions({
+      system,
+      company_id: params.companyId,
+      name: params.name,
+      question_text: params.questionText,
+      question_type: params.questionType,
+      category: params.category,
+      identifier_type: params.identifierType,
+      accept_other: params.acceptOther,
+      options: params.options,
+    });
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/delete-form-preliminary-library-block/use-cases/delete-form-preliminary-library-block.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/delete-form-preliminary-library-block/use-cases/delete-form-preliminary-library-block.usecase.ts
@@ -1,0 +1,22 @@
+import { assertMutableByCompany } from '@/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation';
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class DeleteFormPreliminaryLibraryBlockUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: { companyId: string; blockId: string }) {
+    const existing = await this.dao.readBlockCompanyScoped(params.companyId, params.blockId);
+    if (!existing) {
+      throw new NotFoundException('Bloco não encontrado ou não pertence à empresa.');
+    }
+    assertMutableByCompany(existing.system);
+
+    const result = await this.dao.softDeleteBlock(params.companyId, params.blockId);
+    if (!result) {
+      throw new NotFoundException('Bloco não encontrado ou não pertence à empresa.');
+    }
+    return result;
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/delete-form-preliminary-library-question/use-cases/delete-form-preliminary-library-question.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/delete-form-preliminary-library-question/use-cases/delete-form-preliminary-library-question.usecase.ts
@@ -1,0 +1,22 @@
+import { assertMutableByCompany } from '@/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation';
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class DeleteFormPreliminaryLibraryQuestionUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: { companyId: string; questionId: string }) {
+    const existing = await this.dao.readQuestionCompanyScoped(params.companyId, params.questionId);
+    if (!existing) {
+      throw new NotFoundException('Pergunta não encontrada ou não pertence à empresa.');
+    }
+    assertMutableByCompany(existing.system);
+
+    const result = await this.dao.softDeleteQuestion(params.companyId, params.questionId);
+    if (!result) {
+      throw new NotFoundException('Pergunta não encontrada ou não pertence à empresa.');
+    }
+    return result;
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/form-preliminary-library-blocks.controller.ts
+++ b/src/@v2/forms/application/form-preliminary-library/form-preliminary-library-blocks.controller.ts
@@ -1,0 +1,109 @@
+import { FormRoutes } from '@/@v2/forms/constants/routes';
+import { JwtAuthGuard } from '@/@v2/shared/guards/jwt-auth.guard';
+import { PermissionEnum } from '@/shared/constants/enum/authorization';
+import { Permissions } from '@/shared/decorators/permissions.decorator';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { BrowseFormPreliminaryLibraryBlocksQuery } from './browse-form-preliminary-library-blocks/controllers/browse-form-preliminary-library-blocks.query';
+import { BrowseFormPreliminaryLibraryBlocksUseCase } from './browse-form-preliminary-library-blocks/use-cases/browse-form-preliminary-library-blocks.usecase';
+import { CreateFormPreliminaryLibraryBlockBody } from './create-form-preliminary-library-block/controllers/create-form-preliminary-library-block.body';
+import { CreateFormPreliminaryLibraryBlockUseCase } from './create-form-preliminary-library-block/use-cases/create-form-preliminary-library-block.usecase';
+import { DeleteFormPreliminaryLibraryBlockUseCase } from './delete-form-preliminary-library-block/use-cases/delete-form-preliminary-library-block.usecase';
+import { ReadFormPreliminaryLibraryBlockUseCase } from './read-form-preliminary-library-block/use-cases/read-form-preliminary-library-block.usecase';
+import { FormPreliminaryLibraryBlockPath, FormPreliminaryLibraryCompanyPath } from './shared/form-preliminary-library.path';
+import { UpdateFormPreliminaryLibraryBlockBody } from './update-form-preliminary-library-block/controllers/update-form-preliminary-library-block.body';
+import { UpdateFormPreliminaryLibraryBlockUseCase } from './update-form-preliminary-library-block/use-cases/update-form-preliminary-library-block.usecase';
+
+@Controller(FormRoutes.FORM_PRELIMINARY_LIBRARY.BLOCKS)
+@UseGuards(JwtAuthGuard)
+export class FormPreliminaryLibraryBlocksController {
+  constructor(
+    private readonly browseUseCase: BrowseFormPreliminaryLibraryBlocksUseCase,
+    private readonly readUseCase: ReadFormPreliminaryLibraryBlockUseCase,
+    private readonly createUseCase: CreateFormPreliminaryLibraryBlockUseCase,
+    private readonly updateUseCase: UpdateFormPreliminaryLibraryBlockUseCase,
+    private readonly deleteUseCase: DeleteFormPreliminaryLibraryBlockUseCase,
+  ) {}
+
+  @Get()
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  browse(@Param() path: FormPreliminaryLibraryCompanyPath, @Query() query: BrowseFormPreliminaryLibraryBlocksQuery) {
+    return this.browseUseCase.execute({
+      companyId: path.companyId,
+      search: query.search,
+      page: query.page,
+      limit: query.limit,
+    });
+  }
+
+  @Get(':blockId')
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  read(@Param() path: FormPreliminaryLibraryBlockPath) {
+    return this.readUseCase.execute({
+      companyId: path.companyId,
+      blockId: path.blockId,
+    });
+  }
+
+  @Post()
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  create(@Param() path: FormPreliminaryLibraryCompanyPath, @Body() body: CreateFormPreliminaryLibraryBlockBody) {
+    return this.createUseCase.execute({
+      companyId: path.companyId,
+      name: body.name,
+      description: body.description,
+      items: body.items.map((i) => ({
+        libraryQuestionId: i.libraryQuestionId,
+        order: i.order,
+      })),
+    });
+  }
+
+  @Patch(':blockId')
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  update(@Param() path: FormPreliminaryLibraryBlockPath, @Body() body: UpdateFormPreliminaryLibraryBlockBody) {
+    return this.updateUseCase.execute({
+      companyId: path.companyId,
+      blockId: path.blockId,
+      name: body.name,
+      description: body.description,
+      items: body.items?.map((i) => ({
+        libraryQuestionId: i.libraryQuestionId,
+        order: i.order,
+      })),
+    });
+  }
+
+  @Delete(':blockId')
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  remove(@Param() path: FormPreliminaryLibraryBlockPath) {
+    return this.deleteUseCase.execute({
+      companyId: path.companyId,
+      blockId: path.blockId,
+    });
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/form-preliminary-library-questions.controller.ts
+++ b/src/@v2/forms/application/form-preliminary-library/form-preliminary-library-questions.controller.ts
@@ -1,0 +1,130 @@
+import { FormRoutes } from '@/@v2/forms/constants/routes';
+import { JwtAuthGuard } from '@/@v2/shared/guards/jwt-auth.guard';
+import { PermissionEnum } from '@/shared/constants/enum/authorization';
+import { Permissions } from '@/shared/decorators/permissions.decorator';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { BrowseFormPreliminaryLibraryQuestionsQuery } from './browse-form-preliminary-library-questions/controllers/browse-form-preliminary-library-questions.query';
+import { BrowseFormPreliminaryLibraryQuestionsUseCase } from './browse-form-preliminary-library-questions/use-cases/browse-form-preliminary-library-questions.usecase';
+import { CreateFormPreliminaryLibraryQuestionBody } from './create-form-preliminary-library-question/controllers/create-form-preliminary-library-question.body';
+import { CreateFormPreliminaryLibraryQuestionUseCase } from './create-form-preliminary-library-question/use-cases/create-form-preliminary-library-question.usecase';
+import { DeleteFormPreliminaryLibraryQuestionUseCase } from './delete-form-preliminary-library-question/use-cases/delete-form-preliminary-library-question.usecase';
+import { ReadFormPreliminaryLibraryQuestionUseCase } from './read-form-preliminary-library-question/use-cases/read-form-preliminary-library-question.usecase';
+import { FormPreliminaryLibraryCompanyPath, FormPreliminaryLibraryQuestionPath } from './shared/form-preliminary-library.path';
+import { UpdateFormPreliminaryLibraryQuestionBody } from './update-form-preliminary-library-question/controllers/update-form-preliminary-library-question.body';
+import { UpdateFormPreliminaryLibraryQuestionUseCase } from './update-form-preliminary-library-question/use-cases/update-form-preliminary-library-question.usecase';
+
+@Controller(FormRoutes.FORM_PRELIMINARY_LIBRARY.QUESTIONS)
+@UseGuards(JwtAuthGuard)
+export class FormPreliminaryLibraryQuestionsController {
+  constructor(
+    private readonly browseUseCase: BrowseFormPreliminaryLibraryQuestionsUseCase,
+    private readonly readUseCase: ReadFormPreliminaryLibraryQuestionUseCase,
+    private readonly createUseCase: CreateFormPreliminaryLibraryQuestionUseCase,
+    private readonly updateUseCase: UpdateFormPreliminaryLibraryQuestionUseCase,
+    private readonly deleteUseCase: DeleteFormPreliminaryLibraryQuestionUseCase,
+  ) {}
+
+  @Get()
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  browse(@Param() path: FormPreliminaryLibraryCompanyPath, @Query() query: BrowseFormPreliminaryLibraryQuestionsQuery) {
+    return this.browseUseCase.execute({
+      companyId: path.companyId,
+      category: query.category,
+      search: query.search,
+      page: query.page,
+      limit: query.limit,
+    });
+  }
+
+  @Get(':questionId')
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  read(@Param() path: FormPreliminaryLibraryQuestionPath) {
+    return this.readUseCase.execute({
+      companyId: path.companyId,
+      questionId: path.questionId,
+    });
+  }
+
+  @Post()
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  create(@Param() path: FormPreliminaryLibraryCompanyPath, @Body() body: CreateFormPreliminaryLibraryQuestionBody) {
+    return this.createUseCase.execute({
+      companyId: path.companyId,
+      name: body.name,
+      questionText: body.questionText,
+      questionType: body.questionType,
+      category: body.category,
+      identifierType: body.identifierType,
+      acceptOther: body.acceptOther,
+      options: body.options.map((o) => ({
+        text: o.text,
+        order: o.order,
+        value: o.value ?? null,
+      })),
+    });
+  }
+
+  @Patch(':questionId')
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  update(@Param() path: FormPreliminaryLibraryQuestionPath, @Body() body: UpdateFormPreliminaryLibraryQuestionBody) {
+    return this.updateUseCase.execute({
+      companyId: path.companyId,
+      questionId: path.questionId,
+      name: body.name,
+      questionText: body.questionText,
+      questionType: body.questionType,
+      category: body.category,
+      identifierType: body.identifierType,
+      acceptOther: body.acceptOther,
+      options: body.options?.map((o) => ({
+        text: o.text,
+        order: o.order,
+        value: o.value ?? null,
+      })),
+    });
+  }
+
+  @Delete(':questionId')
+  @Permissions({
+    code: PermissionEnum.FORM,
+    isContract: true,
+    isMember: true,
+    crud: true,
+  })
+  remove(@Param() path: FormPreliminaryLibraryQuestionPath) {
+    return this.deleteUseCase.execute({
+      companyId: path.companyId,
+      questionId: path.questionId,
+    });
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/read-form-preliminary-library-block/use-cases/read-form-preliminary-library-block.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/read-form-preliminary-library-block/use-cases/read-form-preliminary-library-block.usecase.ts
@@ -1,0 +1,15 @@
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class ReadFormPreliminaryLibraryBlockUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: { companyId: string; blockId: string }) {
+    const row = await this.dao.readBlockDetailForCompany(params.companyId, params.blockId);
+    if (!row) {
+      throw new NotFoundException('Bloco não encontrado na biblioteca.');
+    }
+    return row;
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/read-form-preliminary-library-question/use-cases/read-form-preliminary-library-question.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/read-form-preliminary-library-question/use-cases/read-form-preliminary-library-question.usecase.ts
@@ -1,0 +1,15 @@
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+@Injectable()
+export class ReadFormPreliminaryLibraryQuestionUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: { companyId: string; questionId: string }) {
+    const row = await this.dao.readQuestionForCompany(params.companyId, params.questionId);
+    if (!row) {
+      throw new NotFoundException('Pergunta não encontrada na biblioteca.');
+    }
+    return row;
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.path.ts
+++ b/src/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.path.ts
@@ -1,0 +1,16 @@
+import { IsString } from 'class-validator';
+
+export class FormPreliminaryLibraryCompanyPath {
+  @IsString()
+  companyId!: string;
+}
+
+export class FormPreliminaryLibraryQuestionPath extends FormPreliminaryLibraryCompanyPath {
+  @IsString()
+  questionId!: string;
+}
+
+export class FormPreliminaryLibraryBlockPath extends FormPreliminaryLibraryCompanyPath {
+  @IsString()
+  blockId!: string;
+}

--- a/src/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation.ts
+++ b/src/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation.ts
@@ -1,0 +1,44 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { FormIdentifierTypeEnum, FormPreliminaryLibraryQuestionTypeEnum } from '@prisma/client';
+
+/** Regra: system global => sem empresa; template de empresa => company_id obrigatório. */
+export function assertValidSystemCompanyPair(system: boolean, companyId: string | null): void {
+  if (system && companyId !== null) {
+    throw new BadRequestException('Template global (system) deve ter company_id nulo.');
+  }
+  if (!system && (companyId === null || companyId === '')) {
+    throw new BadRequestException('Template da empresa requer company_id.');
+  }
+}
+
+export function rejectSectorIdentifierForLibrary(identifierType: FormIdentifierTypeEnum): void {
+  if (identifierType === FormIdentifierTypeEnum.SECTOR) {
+    throw new BadRequestException(
+      'O tipo de identificador SECTOR não é permitido na biblioteca de perguntas preliminares.',
+    );
+  }
+}
+
+export function assertMutableByCompany(system: boolean): void {
+  if (system) {
+    throw new ForbiddenException('Templates globais do sistema não podem ser alterados por esta rota.');
+  }
+}
+
+export function validateOptionsForQuestionType(
+  questionType: FormPreliminaryLibraryQuestionTypeEnum,
+  identifierType: FormIdentifierTypeEnum,
+  options: { text: string; order: number; value?: number | null }[],
+): void {
+  if (questionType === FormPreliminaryLibraryQuestionTypeEnum.TEXT) {
+    if (options.length > 0) {
+      throw new BadRequestException('Perguntas do tipo TEXT não devem ter opções na biblioteca (V1).');
+    }
+    return;
+  }
+  if (questionType === FormPreliminaryLibraryQuestionTypeEnum.SINGLE_CHOICE) {
+    if (identifierType === FormIdentifierTypeEnum.CUSTOM && options.length < 2) {
+      throw new BadRequestException('Escolha única (CUSTOM) exige pelo menos duas opções.');
+    }
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-block/controllers/update-form-preliminary-library-block.body.ts
+++ b/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-block/controllers/update-form-preliminary-library-block.body.ts
@@ -1,0 +1,20 @@
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { CreateFormPreliminaryLibraryBlockItemBody } from '../../create-form-preliminary-library-block/controllers/create-form-preliminary-library-block.body';
+
+export class UpdateFormPreliminaryLibraryBlockBody {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateFormPreliminaryLibraryBlockItemBody)
+  @ArrayMinSize(1)
+  items?: CreateFormPreliminaryLibraryBlockItemBody[];
+}

--- a/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-block/use-cases/update-form-preliminary-library-block.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-block/use-cases/update-form-preliminary-library-block.usecase.ts
@@ -1,0 +1,48 @@
+import { assertMutableByCompany } from '@/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation';
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+
+export namespace UpdateFormPreliminaryLibraryBlockUseCase {
+  export type Params = {
+    companyId: string;
+    blockId: string;
+    name?: string;
+    description?: string | null;
+    items?: { libraryQuestionId: string; order: number }[];
+  };
+}
+
+@Injectable()
+export class UpdateFormPreliminaryLibraryBlockUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: UpdateFormPreliminaryLibraryBlockUseCase.Params) {
+    const existing = await this.dao.readBlockCompanyScoped(params.companyId, params.blockId);
+    if (!existing) {
+      throw new NotFoundException('Bloco não encontrado ou não pertence à empresa.');
+    }
+    assertMutableByCompany(existing.system);
+
+    if (params.items !== undefined) {
+      if (!params.items.length) {
+        throw new BadRequestException('O bloco deve conter pelo menos uma pergunta.');
+      }
+      const questionIds = params.items.map((i) => i.libraryQuestionId);
+      await this.dao.assertQuestionsAccessibleForBlock(params.companyId, questionIds);
+    }
+
+    const updated = await this.dao.updateBlockWithItems(params.companyId, params.blockId, {
+      name: params.name,
+      description: params.description,
+      items: params.items?.map((i) => ({
+        library_question_id: i.libraryQuestionId,
+        order: i.order,
+      })),
+    });
+
+    if (!updated) {
+      throw new NotFoundException('Bloco não encontrado ou não pertence à empresa.');
+    }
+    return updated;
+  }
+}

--- a/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-question/controllers/update-form-preliminary-library-question.body.ts
+++ b/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-question/controllers/update-form-preliminary-library-question.body.ts
@@ -1,0 +1,50 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import {
+  FormIdentifierTypeEnum,
+  FormPreliminaryLibraryCategoryEnum,
+  FormPreliminaryLibraryQuestionTypeEnum,
+} from '@prisma/client';
+import { CreateFormPreliminaryLibraryQuestionOptionBody } from '../../create-form-preliminary-library-question/controllers/create-form-preliminary-library-question.body';
+
+export class UpdateFormPreliminaryLibraryQuestionBody {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  questionText?: string;
+
+  @IsOptional()
+  @IsEnum(FormPreliminaryLibraryQuestionTypeEnum)
+  questionType?: FormPreliminaryLibraryQuestionTypeEnum;
+
+  @IsOptional()
+  @IsEnum(FormPreliminaryLibraryCategoryEnum)
+  category?: FormPreliminaryLibraryCategoryEnum;
+
+  @IsOptional()
+  @IsEnum(FormIdentifierTypeEnum)
+  identifierType?: FormIdentifierTypeEnum;
+
+  @IsOptional()
+  @IsBoolean()
+  acceptOther?: boolean;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateFormPreliminaryLibraryQuestionOptionBody)
+  @ArrayMinSize(0)
+  options?: CreateFormPreliminaryLibraryQuestionOptionBody[];
+}

--- a/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-question/use-cases/update-form-preliminary-library-question.usecase.ts
+++ b/src/@v2/forms/application/form-preliminary-library/update-form-preliminary-library-question/use-cases/update-form-preliminary-library-question.usecase.ts
@@ -1,0 +1,62 @@
+import {
+  assertMutableByCompany,
+  rejectSectorIdentifierForLibrary,
+  validateOptionsForQuestionType,
+} from '@/@v2/forms/application/form-preliminary-library/shared/form-preliminary-library.validation';
+import { FormPreliminaryLibraryDAO } from '@/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  FormIdentifierTypeEnum,
+  FormPreliminaryLibraryCategoryEnum,
+  FormPreliminaryLibraryQuestionTypeEnum,
+} from '@prisma/client';
+
+export namespace UpdateFormPreliminaryLibraryQuestionUseCase {
+  export type Params = {
+    companyId: string;
+    questionId: string;
+    name?: string;
+    questionText?: string;
+    questionType?: FormPreliminaryLibraryQuestionTypeEnum;
+    category?: FormPreliminaryLibraryCategoryEnum;
+    identifierType?: FormIdentifierTypeEnum;
+    acceptOther?: boolean;
+    options?: { text: string; order: number; value?: number | null }[];
+  };
+}
+
+@Injectable()
+export class UpdateFormPreliminaryLibraryQuestionUseCase {
+  constructor(private readonly dao: FormPreliminaryLibraryDAO) {}
+
+  async execute(params: UpdateFormPreliminaryLibraryQuestionUseCase.Params) {
+    const existing = await this.dao.readQuestionCompanyScoped(params.companyId, params.questionId);
+    if (!existing) {
+      throw new NotFoundException('Pergunta não encontrada ou não pertence à empresa.');
+    }
+    assertMutableByCompany(existing.system);
+
+    const identifierType = params.identifierType ?? existing.identifier_type;
+    const questionType = params.questionType ?? existing.question_type;
+    rejectSectorIdentifierForLibrary(identifierType);
+
+    if (params.options !== undefined) {
+      validateOptionsForQuestionType(questionType, identifierType, params.options);
+    }
+
+    const updated = await this.dao.updateQuestionWithOptions(params.companyId, params.questionId, {
+      name: params.name,
+      question_text: params.questionText,
+      question_type: params.questionType,
+      category: params.category,
+      identifier_type: params.identifierType,
+      accept_other: params.acceptOther,
+      options: params.options,
+    });
+
+    if (!updated) {
+      throw new NotFoundException('Pergunta não encontrada ou não pertence à empresa.');
+    }
+    return updated;
+  }
+}

--- a/src/@v2/forms/constants/routes.ts
+++ b/src/@v2/forms/constants/routes.ts
@@ -30,4 +30,9 @@ export const FormRoutes = {
     PATH: 'v2/companies/:companyId/forms/applications/:applicationId/participants/',
     SEND_EMAIL: 'v2/companies/:companyId/forms/applications/:applicationId/participants/send-email',
   },
+  /** Biblioteca de Perguntas Preliminares (templates; cópia na aplicação na fase seguinte). */
+  FORM_PRELIMINARY_LIBRARY: {
+    QUESTIONS: 'v2/companies/:companyId/forms/preliminary-library/questions',
+    BLOCKS: 'v2/companies/:companyId/forms/preliminary-library/blocks',
+  },
 } as const;

--- a/src/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao.ts
+++ b/src/@v2/forms/database/dao/form-preliminary-library/form-preliminary-library.dao.ts
@@ -1,0 +1,368 @@
+import { PrismaServiceV2 } from '@/@v2/shared/adapters/database/prisma.service';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  FormIdentifierTypeEnum,
+  FormPreliminaryLibraryCategoryEnum,
+  FormPreliminaryLibraryQuestionTypeEnum,
+  Prisma,
+} from '@prisma/client';
+
+const questionListInclude = {
+  options: {
+    where: { deleted_at: null },
+    orderBy: { order: 'asc' as const },
+  },
+} satisfies Prisma.FormPreliminaryLibraryQuestionInclude;
+
+const blockDetailInclude = {
+  items: {
+    orderBy: { order: 'asc' as const },
+    include: {
+      library_question: {
+        include: {
+          options: {
+            where: { deleted_at: null },
+            orderBy: { order: 'asc' as const },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.FormPreliminaryLibraryBlockInclude;
+
+export type FormPreliminaryLibraryQuestionWithOptions = Prisma.FormPreliminaryLibraryQuestionGetPayload<{
+  include: typeof questionListInclude;
+}>;
+
+export type FormPreliminaryLibraryBlockDetail = Prisma.FormPreliminaryLibraryBlockGetPayload<{
+  include: typeof blockDetailInclude;
+}>;
+
+@Injectable()
+export class FormPreliminaryLibraryDAO {
+  constructor(private readonly prisma: PrismaServiceV2) {}
+
+  private accessibleWhere(companyId: string): Prisma.FormPreliminaryLibraryQuestionWhereInput {
+    return {
+      deleted_at: null,
+      OR: [{ system: true }, { company_id: companyId }],
+    };
+  }
+
+  private accessibleWhereBlock(companyId: string): Prisma.FormPreliminaryLibraryBlockWhereInput {
+    return {
+      deleted_at: null,
+      OR: [{ system: true }, { company_id: companyId }],
+    };
+  }
+
+  async browseQuestions(params: {
+    companyId: string;
+    category?: FormPreliminaryLibraryCategoryEnum;
+    search?: string;
+    skip: number;
+    take: number;
+  }) {
+    const where: Prisma.FormPreliminaryLibraryQuestionWhereInput = {
+      AND: [
+        this.accessibleWhere(params.companyId),
+        ...(params.category ? [{ category: params.category }] : []),
+        ...(params.search
+          ? [
+              {
+                OR: [
+                  { name: { contains: params.search, mode: Prisma.QueryMode.insensitive } },
+                  { question_text: { contains: params.search, mode: Prisma.QueryMode.insensitive } },
+                ],
+              },
+            ]
+          : []),
+      ],
+    };
+
+    const [data, count] = await this.prisma.$transaction([
+      this.prisma.formPreliminaryLibraryQuestion.findMany({
+        where,
+        include: questionListInclude,
+        orderBy: [{ category: 'asc' }, { name: 'asc' }],
+        skip: params.skip,
+        take: params.take,
+      }),
+      this.prisma.formPreliminaryLibraryQuestion.count({ where }),
+    ]);
+
+    return { data, count };
+  }
+
+  async readQuestionForCompany(companyId: string, questionId: string) {
+    return this.prisma.formPreliminaryLibraryQuestion.findFirst({
+      where: {
+        id: questionId,
+        ...this.accessibleWhere(companyId),
+      },
+      include: questionListInclude,
+    });
+  }
+
+  async readQuestionCompanyScoped(companyId: string, questionId: string) {
+    return this.prisma.formPreliminaryLibraryQuestion.findFirst({
+      where: {
+        id: questionId,
+        company_id: companyId,
+        deleted_at: null,
+      },
+      include: questionListInclude,
+    });
+  }
+
+  async createQuestionWithOptions(
+    data: {
+      system: boolean;
+      company_id: string | null;
+      name: string;
+      question_text: string;
+      question_type: FormPreliminaryLibraryQuestionTypeEnum;
+      category: FormPreliminaryLibraryCategoryEnum;
+      identifier_type: FormIdentifierTypeEnum;
+      accept_other: boolean;
+      options: { text: string; order: number; value?: number | null }[];
+    },
+    tx?: Prisma.TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+    return client.formPreliminaryLibraryQuestion.create({
+      data: {
+        system: data.system,
+        company_id: data.company_id,
+        name: data.name,
+        question_text: data.question_text,
+        question_type: data.question_type,
+        category: data.category,
+        identifier_type: data.identifier_type,
+        accept_other: data.accept_other,
+        options: {
+          create: data.options.map((o) => ({
+            text: o.text,
+            order: o.order,
+            value: o.value ?? null,
+          })),
+        },
+      },
+      include: questionListInclude,
+    });
+  }
+
+  async updateQuestionWithOptions(
+    companyId: string,
+    questionId: string,
+    data: {
+      name?: string;
+      question_text?: string;
+      question_type?: FormPreliminaryLibraryQuestionTypeEnum;
+      category?: FormPreliminaryLibraryCategoryEnum;
+      identifier_type?: FormIdentifierTypeEnum;
+      accept_other?: boolean;
+      options?: { text: string; order: number; value?: number | null }[];
+    },
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const existing = await tx.formPreliminaryLibraryQuestion.findFirst({
+        where: { id: questionId, company_id: companyId, system: false, deleted_at: null },
+      });
+      if (!existing) return null;
+
+      if (data.options !== undefined) {
+        const now = new Date();
+        await tx.formPreliminaryLibraryQuestionOption.updateMany({
+          where: { library_question_id: questionId, deleted_at: null },
+          data: { deleted_at: now },
+        });
+        await tx.formPreliminaryLibraryQuestionOption.createMany({
+          data: data.options.map((o) => ({
+            library_question_id: questionId,
+            text: o.text,
+            order: o.order,
+            value: o.value ?? null,
+          })),
+        });
+      }
+
+      return tx.formPreliminaryLibraryQuestion.update({
+        where: { id: questionId },
+        data: {
+          ...(data.name !== undefined ? { name: data.name } : {}),
+          ...(data.question_text !== undefined ? { question_text: data.question_text } : {}),
+          ...(data.question_type !== undefined ? { question_type: data.question_type } : {}),
+          ...(data.category !== undefined ? { category: data.category } : {}),
+          ...(data.identifier_type !== undefined ? { identifier_type: data.identifier_type } : {}),
+          ...(data.accept_other !== undefined ? { accept_other: data.accept_other } : {}),
+        },
+        include: questionListInclude,
+      });
+    });
+  }
+
+  async softDeleteQuestion(companyId: string, questionId: string) {
+    const existing = await this.prisma.formPreliminaryLibraryQuestion.findFirst({
+      where: { id: questionId, company_id: companyId, system: false, deleted_at: null },
+    });
+    if (!existing) return null;
+    const now = new Date();
+    await this.prisma.$transaction([
+      this.prisma.formPreliminaryLibraryQuestionOption.updateMany({
+        where: { library_question_id: questionId, deleted_at: null },
+        data: { deleted_at: now },
+      }),
+      this.prisma.formPreliminaryLibraryQuestion.update({
+        where: { id: questionId },
+        data: { deleted_at: now },
+      }),
+    ]);
+    return { id: questionId };
+  }
+
+  async browseBlocks(params: { companyId: string; search?: string; skip: number; take: number }) {
+    const where: Prisma.FormPreliminaryLibraryBlockWhereInput = {
+      AND: [
+        this.accessibleWhereBlock(params.companyId),
+        ...(params.search
+          ? [
+              {
+                OR: [
+                  { name: { contains: params.search, mode: Prisma.QueryMode.insensitive } },
+                  { description: { contains: params.search, mode: Prisma.QueryMode.insensitive } },
+                ],
+              },
+            ]
+          : []),
+      ],
+    };
+
+    const [data, count] = await this.prisma.$transaction([
+      this.prisma.formPreliminaryLibraryBlock.findMany({
+        where,
+        orderBy: { name: 'asc' },
+        skip: params.skip,
+        take: params.take,
+      }),
+      this.prisma.formPreliminaryLibraryBlock.count({ where }),
+    ]);
+
+    return { data, count };
+  }
+
+  async readBlockDetailForCompany(companyId: string, blockId: string) {
+    return this.prisma.formPreliminaryLibraryBlock.findFirst({
+      where: {
+        id: blockId,
+        ...this.accessibleWhereBlock(companyId),
+      },
+      include: blockDetailInclude,
+    });
+  }
+
+  async readBlockCompanyScoped(companyId: string, blockId: string) {
+    return this.prisma.formPreliminaryLibraryBlock.findFirst({
+      where: {
+        id: blockId,
+        company_id: companyId,
+        deleted_at: null,
+      },
+      include: blockDetailInclude,
+    });
+  }
+
+  async createBlockWithItems(
+    data: {
+      system: boolean;
+      company_id: string | null;
+      name: string;
+      description?: string | null;
+      items: { library_question_id: string; order: number }[];
+    },
+    tx?: Prisma.TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+    return client.formPreliminaryLibraryBlock.create({
+      data: {
+        system: data.system,
+        company_id: data.company_id,
+        name: data.name,
+        description: data.description ?? null,
+        items: {
+          create: data.items.map((i) => ({
+            library_question_id: i.library_question_id,
+            order: i.order,
+          })),
+        },
+      },
+      include: blockDetailInclude,
+    });
+  }
+
+  async updateBlockWithItems(
+    companyId: string,
+    blockId: string,
+    data: {
+      name?: string;
+      description?: string | null;
+      items?: { library_question_id: string; order: number }[];
+    },
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const existing = await tx.formPreliminaryLibraryBlock.findFirst({
+        where: { id: blockId, company_id: companyId, system: false, deleted_at: null },
+      });
+      if (!existing) return null;
+
+      if (data.items) {
+        await tx.formPreliminaryLibraryBlockItem.deleteMany({ where: { block_id: blockId } });
+        await tx.formPreliminaryLibraryBlockItem.createMany({
+          data: data.items.map((i) => ({
+            block_id: blockId,
+            library_question_id: i.library_question_id,
+            order: i.order,
+          })),
+        });
+      }
+
+      return tx.formPreliminaryLibraryBlock.update({
+        where: { id: blockId },
+        data: {
+          ...(data.name !== undefined ? { name: data.name } : {}),
+          ...(data.description !== undefined ? { description: data.description } : {}),
+        },
+        include: blockDetailInclude,
+      });
+    });
+  }
+
+  async softDeleteBlock(companyId: string, blockId: string) {
+    const existing = await this.prisma.formPreliminaryLibraryBlock.findFirst({
+      where: { id: blockId, company_id: companyId, system: false, deleted_at: null },
+    });
+    if (!existing) return null;
+    const now = new Date();
+    await this.prisma.formPreliminaryLibraryBlock.update({
+      where: { id: blockId },
+      data: { deleted_at: now },
+    });
+    return { id: blockId };
+  }
+
+  /** Valida que todas as perguntas existem e são acessíveis ao escopo (sistema + empresa). */
+  async assertQuestionsAccessibleForBlock(companyId: string, questionIds: string[]) {
+    const unique = [...new Set(questionIds)];
+    const found = await this.prisma.formPreliminaryLibraryQuestion.findMany({
+      where: {
+        id: { in: unique },
+        deleted_at: null,
+        OR: [{ system: true }, { company_id: companyId }],
+      },
+      select: { id: true },
+    });
+    if (found.length !== unique.length) {
+      throw new BadRequestException('Uma ou mais perguntas não foram encontradas ou não estão acessíveis.');
+    }
+  }
+}

--- a/src/@v2/forms/forms.module.ts
+++ b/src/@v2/forms/forms.module.ts
@@ -69,6 +69,19 @@ import { EditFormQuestionsAnswersAnalysisController } from './application/form-q
 import { EditFormQuestionsAnswersAnalysisUseCase } from './application/form-questions-answers/edit-form-questions-answers-analysis/use-cases/edit-form-questions-answers-analysis.usecase';
 import { PublicFormParticipantLoginController } from './application/form-application/public-form-participant-login/controllers/public-form-participant-login.controller';
 import { PublicFormParticipantLoginUseCase } from './application/form-application/public-form-participant-login/use-cases/public-form-participant-login.usecase';
+import { BrowseFormPreliminaryLibraryBlocksUseCase } from './application/form-preliminary-library/browse-form-preliminary-library-blocks/use-cases/browse-form-preliminary-library-blocks.usecase';
+import { BrowseFormPreliminaryLibraryQuestionsUseCase } from './application/form-preliminary-library/browse-form-preliminary-library-questions/use-cases/browse-form-preliminary-library-questions.usecase';
+import { CreateFormPreliminaryLibraryBlockUseCase } from './application/form-preliminary-library/create-form-preliminary-library-block/use-cases/create-form-preliminary-library-block.usecase';
+import { CreateFormPreliminaryLibraryQuestionUseCase } from './application/form-preliminary-library/create-form-preliminary-library-question/use-cases/create-form-preliminary-library-question.usecase';
+import { DeleteFormPreliminaryLibraryBlockUseCase } from './application/form-preliminary-library/delete-form-preliminary-library-block/use-cases/delete-form-preliminary-library-block.usecase';
+import { DeleteFormPreliminaryLibraryQuestionUseCase } from './application/form-preliminary-library/delete-form-preliminary-library-question/use-cases/delete-form-preliminary-library-question.usecase';
+import { FormPreliminaryLibraryBlocksController } from './application/form-preliminary-library/form-preliminary-library-blocks.controller';
+import { FormPreliminaryLibraryQuestionsController } from './application/form-preliminary-library/form-preliminary-library-questions.controller';
+import { ReadFormPreliminaryLibraryBlockUseCase } from './application/form-preliminary-library/read-form-preliminary-library-block/use-cases/read-form-preliminary-library-block.usecase';
+import { ReadFormPreliminaryLibraryQuestionUseCase } from './application/form-preliminary-library/read-form-preliminary-library-question/use-cases/read-form-preliminary-library-question.usecase';
+import { UpdateFormPreliminaryLibraryBlockUseCase } from './application/form-preliminary-library/update-form-preliminary-library-block/use-cases/update-form-preliminary-library-block.usecase';
+import { UpdateFormPreliminaryLibraryQuestionUseCase } from './application/form-preliminary-library/update-form-preliminary-library-question/use-cases/update-form-preliminary-library-question.usecase';
+import { FormPreliminaryLibraryDAO } from './database/dao/form-preliminary-library/form-preliminary-library.dao';
 import { SSTModule } from '@/modules/sst/sst.module';
 
 @Module({
@@ -98,6 +111,8 @@ import { SSTModule } from '@/modules/sst/sst.module';
     BrowseFormQuestionsAnswersAnalysisController,
     EditFormQuestionsAnswersAnalysisController,
     PublicFormParticipantLoginController,
+    FormPreliminaryLibraryQuestionsController,
+    FormPreliminaryLibraryBlocksController,
   ],
   providers: [
     // Database
@@ -147,6 +162,17 @@ import { SSTModule } from '@/modules/sst/sst.module';
     // Services
     FormApplicationCacheService,
     FormQuestionsAnswersRisksService,
+    FormPreliminaryLibraryDAO,
+    BrowseFormPreliminaryLibraryQuestionsUseCase,
+    ReadFormPreliminaryLibraryQuestionUseCase,
+    CreateFormPreliminaryLibraryQuestionUseCase,
+    UpdateFormPreliminaryLibraryQuestionUseCase,
+    DeleteFormPreliminaryLibraryQuestionUseCase,
+    BrowseFormPreliminaryLibraryBlocksUseCase,
+    ReadFormPreliminaryLibraryBlockUseCase,
+    CreateFormPreliminaryLibraryBlockUseCase,
+    UpdateFormPreliminaryLibraryBlockUseCase,
+    DeleteFormPreliminaryLibraryBlockUseCase,
   ],
   exports: [],
 })


### PR DESCRIPTION
## Objetivo
Adicionar o suporte de backend para a **Biblioteca de Perguntas Preliminares** no módulo de Formulários, incluindo perguntas reutilizáveis, blocos reutilizáveis e seed inicial com perguntas demográficas padrão.

## O que foi entregue
- estrutura de backend para biblioteca de perguntas preliminares
- endpoints para perguntas da biblioteca
- endpoints para blocos da biblioteca
- leitura de perguntas e blocos por empresa + itens de sistema
- suporte a seed inicial da biblioteca
- inclusão do bloco demográfico padrão no ambiente
- validações de integridade e escopo
- suporte para consumo pelo client no fluxo de criação/edição de aplicações

## Estrutura adicionada
- perguntas preliminares reutilizáveis
- opções de perguntas
- blocos de perguntas
- itens de bloco
- seed com:
  - 7 perguntas demográficas
  - 1 bloco **Bloco Demográfico Padrão**

## Regras de negócio aplicadas
- itens `system` são globais e somente leitura
- itens da empresa podem coexistir com itens de sistema
- listagem retorna biblioteca global + biblioteca da empresa
- perguntas da biblioteca demográfica usam `CUSTOM`
- biblioteca não deve interferir na lógica estrutural de `SECTOR`
- consumo pela aplicação é por cópia, sem vínculo vivo com a biblioteca

## Validação realizada
- migração aplicada
- seed executado com sucesso
- perguntas apareceram na aba da biblioteca no client
- bloco apareceu corretamente no client
- client conseguiu consumir perguntas e blocos da biblioteca
- fluxo ponta a ponta validado em conjunto com a branch do client

## Observação
Essa PR cobre o **backend** da funcionalidade. A integração visual e de uso está na PR correspondente do **client**.